### PR TITLE
fix: update links from journey.ergohaven.xyz to docs.ergohaven.xyz and zmk repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 | [Firmware update guide][01]  | [Инструкция по прошивке][02] | [QMK Source code][03] | [ZMK Source code][04] |
 | ---------------------------  | ---------------------------- | --------------------- | --------------------- |
 
-[01]: https://journey.ergohaven.xyz/en-gb/pages/docs/
-[02]: https://journey.ergohaven.xyz/pages/docs/
+[01]: https://docs.ergohaven.xyz/en/
+[02]: https://docs.ergohaven.xyz/
 [03]: https://github.com/ergohaven/vial-qmk
-[04]: https://github.com/ergohaven/?q=zmk&type=all&language=&sort=
+[04]: https://github.com/ergohaven/ergohaven-zmk
 
 
 ## QMK (wired)


### PR DESCRIPTION
Исправлены устаревшие ссылки:
- `https://journey.ergohaven.xyz/en-gb/pages/docs/` → `https://docs.ergohaven.xyz/en/`
- `https://journey.ergohaven.xyz/pages/docs/` → `https://docs.ergohaven.xyz/`
- `https://github.com/ergohaven/?q=zmk&type=all&language=&sort=` → `https://github.com/ergohaven/ergohaven-zmk`